### PR TITLE
fix: Terminal URL scheme調査に基づく技術的制限への対応

### DIFF
--- a/editor-presets.js
+++ b/editor-presets.js
@@ -17,10 +17,6 @@ const PRESET_TYPES = {
   GUI: 'gui',
   COMMAND: 'command',
   TOOLBOX: 'toolbox'
-  // Terminal系は技術的制限により無効化
-  // TERMINAL: 'terminal',
-  // TERMINAL_EDITOR: 'terminal_editor',
-  // COPY_COMMAND: 'copy_command'
 };
 
 /**
@@ -64,31 +60,6 @@ class EditorPresetManager {
         type: PRESET_TYPES.TOOLBOX,
         supported: SUPPORT_STATUS.TOOLBOX_REQUIRED
       }
-      // Terminal系プリセットは技術的制限により無効化
-      // Chrome拡張ではURL schemeでのTerminal起動ができないため
-      /*
-      terminal_mac: {
-        name: 'Terminal (macOS)',
-        description: '技術的制限により利用不可: Chrome拡張ではTerminal起動URL schemeが存在しません',
-        type: PRESET_TYPES.UNAVAILABLE,
-        platform: PLATFORMS.DARWIN,
-        supported: false
-      },
-      iterm2: {
-        name: 'iTerm2',
-        description: '技術的制限により利用不可: セキュリティ上の理由で2011年に機能削除済み',
-        type: PRESET_TYPES.UNAVAILABLE,
-        platform: PLATFORMS.DARWIN,
-        supported: false
-      },
-      nvim_terminal: {
-        name: 'Neovim in Terminal',
-        description: '技術的制限により利用不可: Terminal起動が前提のため利用できません',
-        type: PRESET_TYPES.UNAVAILABLE,
-        platform: PLATFORMS.DARWIN,
-        supported: false
-      }
-      */
     };
   }
 
@@ -164,8 +135,6 @@ class EditorPresetManager {
     return preset.command.replace('{path}', fullPath);
   }
 
-  // コマンドコピー機能は技術的制限により削除
-  // isCopyCommandType() メソッドは利用不可
 
   /**
    * 現在のプラットフォームを取得する

--- a/editor-presets.js
+++ b/editor-presets.js
@@ -16,10 +16,11 @@ const PLATFORMS = {
 const PRESET_TYPES = {
   GUI: 'gui',
   COMMAND: 'command',
-  TOOLBOX: 'toolbox',
-  TERMINAL: 'terminal',
-  TERMINAL_EDITOR: 'terminal_editor',
-  COPY_COMMAND: 'copy_command'
+  TOOLBOX: 'toolbox'
+  // Terminal系は技術的制限により無効化
+  // TERMINAL: 'terminal',
+  // TERMINAL_EDITOR: 'terminal_editor',
+  // COPY_COMMAND: 'copy_command'
 };
 
 /**
@@ -62,31 +63,32 @@ class EditorPresetManager {
         scheme: 'jetbrains://idea/navigate/reference?project=',
         type: PRESET_TYPES.TOOLBOX,
         supported: SUPPORT_STATUS.TOOLBOX_REQUIRED
-      },
+      }
+      // Terminal系プリセットは技術的制限により無効化
+      // Chrome拡張ではURL schemeでのTerminal起動ができないため
+      /*
       terminal_mac: {
-        name: 'Terminal (macOS) - コマンドコピー',
-        command: 'osascript -e \'tell application "Terminal" to do script "cd {path}"\'',
-        type: PRESET_TYPES.COPY_COMMAND,
+        name: 'Terminal (macOS)',
+        description: '技術的制限により利用不可: Chrome拡張ではTerminal起動URL schemeが存在しません',
+        type: PRESET_TYPES.UNAVAILABLE,
         platform: PLATFORMS.DARWIN,
-        supported: SUPPORT_STATUS.COMMAND_LINE,
-        description: 'Terminalアプリでディレクトリを開くAppleScriptコマンドをクリップボードにコピーします'
+        supported: false
       },
       iterm2: {
-        name: 'iTerm2 - コマンドコピー',
-        command: 'osascript -e \'tell application "iTerm" to create window with default profile command "cd {path}"\'',
-        type: PRESET_TYPES.COPY_COMMAND,
+        name: 'iTerm2',
+        description: '技術的制限により利用不可: セキュリティ上の理由で2011年に機能削除済み',
+        type: PRESET_TYPES.UNAVAILABLE,
         platform: PLATFORMS.DARWIN,
-        supported: SUPPORT_STATUS.COMMAND_LINE,
-        description: 'iTerm2でディレクトリを開くAppleScriptコマンドをクリップボードにコピーします'
+        supported: false
       },
       nvim_terminal: {
-        name: 'Neovim in Terminal - コマンドコピー',
-        command: 'osascript -e \'tell application "Terminal" to do script "cd {path} && nvim ."\'',
-        type: PRESET_TYPES.COPY_COMMAND,
+        name: 'Neovim in Terminal',
+        description: '技術的制限により利用不可: Terminal起動が前提のため利用できません',
+        type: PRESET_TYPES.UNAVAILABLE,
         platform: PLATFORMS.DARWIN,
-        supported: SUPPORT_STATUS.COMMAND_LINE,
-        description: 'TerminalでNeovimを起動するAppleScriptコマンドをクリップボードにコピーします'
+        supported: false
       }
+      */
     };
   }
 
@@ -162,15 +164,8 @@ class EditorPresetManager {
     return preset.command.replace('{path}', fullPath);
   }
 
-  /**
-   * プリセットがコマンドコピータイプかを判定する
-   * @param {string} presetId - プリセットID
-   * @returns {boolean} コマンドコピータイプの場合true
-   */
-  isCopyCommandType(presetId) {
-    const preset = this.getPreset(presetId);
-    return preset.type === PRESET_TYPES.COPY_COMMAND;
-  }
+  // コマンドコピー機能は技術的制限により削除
+  // isCopyCommandType() メソッドは利用不可
 
   /**
    * 現在のプラットフォームを取得する

--- a/editor-presets.js
+++ b/editor-presets.js
@@ -18,7 +18,8 @@ const PRESET_TYPES = {
   COMMAND: 'command',
   TOOLBOX: 'toolbox',
   TERMINAL: 'terminal',
-  TERMINAL_EDITOR: 'terminal_editor'
+  TERMINAL_EDITOR: 'terminal_editor',
+  COPY_COMMAND: 'copy_command'
 };
 
 /**
@@ -63,22 +64,28 @@ class EditorPresetManager {
         supported: SUPPORT_STATUS.TOOLBOX_REQUIRED
       },
       terminal_mac: {
-        name: 'Terminal (macOS)',
+        name: 'Terminal (macOS) - コマンドコピー',
         command: 'osascript -e \'tell application "Terminal" to do script "cd {path}"\'',
-        type: PRESET_TYPES.TERMINAL,
-        platform: PLATFORMS.DARWIN
+        type: PRESET_TYPES.COPY_COMMAND,
+        platform: PLATFORMS.DARWIN,
+        supported: SUPPORT_STATUS.COMMAND_LINE,
+        description: 'Terminalアプリでディレクトリを開くAppleScriptコマンドをクリップボードにコピーします'
       },
       iterm2: {
-        name: 'iTerm2',
+        name: 'iTerm2 - コマンドコピー',
         command: 'osascript -e \'tell application "iTerm" to create window with default profile command "cd {path}"\'',
-        type: PRESET_TYPES.TERMINAL,
-        platform: PLATFORMS.DARWIN
+        type: PRESET_TYPES.COPY_COMMAND,
+        platform: PLATFORMS.DARWIN,
+        supported: SUPPORT_STATUS.COMMAND_LINE,
+        description: 'iTerm2でディレクトリを開くAppleScriptコマンドをクリップボードにコピーします'
       },
       nvim_terminal: {
-        name: 'Neovim in Terminal',
+        name: 'Neovim in Terminal - コマンドコピー',
         command: 'osascript -e \'tell application "Terminal" to do script "cd {path} && nvim ."\'',
-        type: PRESET_TYPES.TERMINAL_EDITOR,
-        platform: PLATFORMS.DARWIN
+        type: PRESET_TYPES.COPY_COMMAND,
+        platform: PLATFORMS.DARWIN,
+        supported: SUPPORT_STATUS.COMMAND_LINE,
+        description: 'TerminalでNeovimを起動するAppleScriptコマンドをクリップボードにコピーします'
       }
     };
   }
@@ -153,6 +160,16 @@ class EditorPresetManager {
 
     const fullPath = `${settings.basePath}${repoInfo.fullName}`;
     return preset.command.replace('{path}', fullPath);
+  }
+
+  /**
+   * プリセットがコマンドコピータイプかを判定する
+   * @param {string} presetId - プリセットID
+   * @returns {boolean} コマンドコピータイプの場合true
+   */
+  isCopyCommandType(presetId) {
+    const preset = this.getPreset(presetId);
+    return preset.type === PRESET_TYPES.COPY_COMMAND;
   }
 
   /**

--- a/popup.html
+++ b/popup.html
@@ -122,6 +122,7 @@
         <div id="error" class="error"></div>
     </div>
     
+    <script src="editor-presets.js"></script>
     <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -120,8 +120,16 @@ async function openInEditor(repoInfo) {
       throw new Error(validation.error);
     }
     
-    // エディタ URL を構築
-    const editorUrl = buildEditorUrl(repoInfo, settings);
+    let editorUrl;
+    
+    // プリセットが設定されている場合はプリセットを使用
+    if (settings.editorPreset && settings.editorPreset !== 'custom') {
+      const presetManager = new EditorPresetManager();
+      editorUrl = presetManager.buildEditorUrl(settings.editorPreset, repoInfo, settings);
+    } else {
+      // カスタム設定の場合は従来の方法を使用
+      editorUrl = buildEditorUrl(repoInfo, settings);
+    }
     
     // URL スキームを開く
     window.open(editorUrl, '_blank');

--- a/popup.js
+++ b/popup.js
@@ -120,21 +120,7 @@ async function openInEditor(repoInfo) {
       throw new Error(validation.error);
     }
     
-    // プリセットが設定されている場合の処理
-    if (settings.editorPreset && settings.editorPreset !== 'custom') {
-      const presetManager = new EditorPresetManager();
-      
-      // コマンドコピータイプの場合
-      if (presetManager.isCopyCommandType(settings.editorPreset)) {
-        const command = presetManager.buildCommand(settings.editorPreset, repoInfo, settings);
-        await copyToClipboard(command);
-        const preset = presetManager.getPreset(settings.editorPreset);
-        showMessage(`コマンドをクリップボードにコピーしました\n${preset.description}`, 'success');
-        return;
-      }
-    }
-    
-    // 通常のURL scheme処理
+    // エディタ URL を構築
     const editorUrl = buildEditorUrl(repoInfo, settings);
     
     // URL スキームを開く
@@ -145,24 +131,6 @@ async function openInEditor(repoInfo) {
     
   } catch (error) {
     showMessage(error.message, 'error');
-  }
-}
-
-/**
- * クリップボードにテキストをコピーする
- * @param {string} text - コピーするテキスト
- */
-async function copyToClipboard(text) {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch (error) {
-    // fallback: テキストエリアを使用
-    const textArea = document.createElement('textarea');
-    textArea.value = text;
-    document.body.appendChild(textArea);
-    textArea.select();
-    document.execCommand('copy');
-    document.body.removeChild(textArea);
   }
 }
 

--- a/settings.js
+++ b/settings.js
@@ -135,14 +135,7 @@ function initializeEditorPresets() {
     presets.forEach(preset => {
       const option = document.createElement('option');
       option.value = preset.id;
-      
-      // プリセットタイプに応じた表示
-      if (preset.type === 'copy_command') {
-        option.textContent = `${preset.name}`;
-      } else {
-        option.textContent = `${preset.name} (${preset.type})`;
-      }
-      
+      option.textContent = `${preset.name} (${preset.type})`;
       select.appendChild(option);
     });
     
@@ -172,10 +165,7 @@ function handlePresetChange(event) {
       const preset = presetManager.getPreset(presetId);
       
       // プリセットの値を設定
-      if (preset.type === 'copy_command') {
-        editorSchemeInput.value = `[コマンドコピー] ${preset.description}`;
-        editorSchemeInput.placeholder = 'コマンドをクリップボードにコピーします';
-      } else if (preset.scheme) {
+      if (preset.scheme) {
         editorSchemeInput.value = preset.scheme;
         editorSchemeInput.placeholder = preset.scheme;
       } else if (preset.command) {

--- a/settings.js
+++ b/settings.js
@@ -135,7 +135,14 @@ function initializeEditorPresets() {
     presets.forEach(preset => {
       const option = document.createElement('option');
       option.value = preset.id;
-      option.textContent = `${preset.name} (${preset.type})`;
+      
+      // プリセットタイプに応じた表示
+      if (preset.type === 'copy_command') {
+        option.textContent = `${preset.name}`;
+      } else {
+        option.textContent = `${preset.name} (${preset.type})`;
+      }
+      
       select.appendChild(option);
     });
     
@@ -158,16 +165,22 @@ function handlePresetChange(event) {
     // カスタム設定の場合は入力を有効にする
     editorSchemeInput.readOnly = false;
     editorSchemeInput.style.backgroundColor = '';
+    editorSchemeInput.placeholder = 'vscode://file';
   } else {
     try {
       const presetManager = new EditorPresetManager();
       const preset = presetManager.getPreset(presetId);
       
       // プリセットの値を設定
-      if (preset.scheme) {
+      if (preset.type === 'copy_command') {
+        editorSchemeInput.value = `[コマンドコピー] ${preset.description}`;
+        editorSchemeInput.placeholder = 'コマンドをクリップボードにコピーします';
+      } else if (preset.scheme) {
         editorSchemeInput.value = preset.scheme;
+        editorSchemeInput.placeholder = preset.scheme;
       } else if (preset.command) {
         editorSchemeInput.value = `command:${preset.command}`;
+        editorSchemeInput.placeholder = 'コマンド実行';
       }
       
       // 読み取り専用にする

--- a/test-editor-presets.js
+++ b/test-editor-presets.js
@@ -104,43 +104,42 @@ function testプリセットからエディタURLを構築できる() {
 }
 
 /**
- * テスト: Terminalプリセットでコマンドを構築できる
+ * テスト: Windsurfプリセットでコマンドを構築できる
  */
-function testTerminalプリセットでコマンドを構築できる() {
+function testWindsurfプリセットでコマンドを構築できる() {
   try {
     const presetManager = new EditorPresetManager();
-    const command = presetManager.buildCommand('terminal_mac', testRepoInfo, { basePath: testBasePath });
+    const command = presetManager.buildCommand('windsurf', testRepoInfo, { basePath: testBasePath });
     
     const expectedPath = '/Users/test/src/github.com/testuser/test-repo';
     const passed = command && command.includes(expectedPath);
     
-    logTestResult('Terminalプリセットでコマンドを構築できる', passed);
+    logTestResult('Windsurfプリセットでコマンドを構築できる', passed);
     if (!passed) {
       console.log(`  Command: ${command}`);
     }
   } catch (error) {
-    logTestResult('Terminalプリセットでコマンドを構築できる', false, error);
+    logTestResult('Windsurfプリセットでコマンドを構築できる', false, error);
   }
 }
 
 /**
- * テスト: コマンドコピータイプを判定できる
+ * テスト: Terminal系プリセットが無効化されている
  */
-function testコマンドコピータイプを判定できる() {
+function testTerminal系プリセットが無効化されている() {
   try {
     const presetManager = new EditorPresetManager();
+    let errorOccurred = false;
     
-    const isTerminalCopyType = presetManager.isCopyCommandType('terminal_mac');
-    const isVSCodeCopyType = presetManager.isCopyCommandType('vscode');
-    
-    const passed = isTerminalCopyType === true && isVSCodeCopyType === false;
-    
-    logTestResult('コマンドコピータイプを判定できる', passed);
-    if (!passed) {
-      console.log(`  terminal_mac: ${isTerminalCopyType}, vscode: ${isVSCodeCopyType}`);
+    try {
+      presetManager.getPreset('terminal_mac');
+    } catch (error) {
+      errorOccurred = true;
     }
+    
+    logTestResult('Terminal系プリセットが無効化されている', errorOccurred);
   } catch (error) {
-    logTestResult('コマンドコピータイプを判定できる', false, error);
+    logTestResult('Terminal系プリセットが無効化されている', false, error);
   }
 }
 
@@ -189,8 +188,8 @@ function runAllTests() {
   testVSCodeプリセットを取得できる();
   test利用可能なプリセット一覧を取得できる();
   testプリセットからエディタURLを構築できる();
-  testTerminalプリセットでコマンドを構築できる();
-  testコマンドコピータイプを判定できる();
+  testWindsurfプリセットでコマンドを構築できる();
+  testTerminal系プリセットが無効化されている();
   test現在のOS向けプリセットのみを取得できる();
   test無効なプリセットIDでエラーが発生する();
   

--- a/test-editor-presets.js
+++ b/test-editor-presets.js
@@ -124,6 +124,27 @@ function testTerminalプリセットでコマンドを構築できる() {
 }
 
 /**
+ * テスト: コマンドコピータイプを判定できる
+ */
+function testコマンドコピータイプを判定できる() {
+  try {
+    const presetManager = new EditorPresetManager();
+    
+    const isTerminalCopyType = presetManager.isCopyCommandType('terminal_mac');
+    const isVSCodeCopyType = presetManager.isCopyCommandType('vscode');
+    
+    const passed = isTerminalCopyType === true && isVSCodeCopyType === false;
+    
+    logTestResult('コマンドコピータイプを判定できる', passed);
+    if (!passed) {
+      console.log(`  terminal_mac: ${isTerminalCopyType}, vscode: ${isVSCodeCopyType}`);
+    }
+  } catch (error) {
+    logTestResult('コマンドコピータイプを判定できる', false, error);
+  }
+}
+
+/**
  * テスト: 現在のOS向けプリセットのみを取得できる
  */
 function test現在のOS向けプリセットのみを取得できる() {
@@ -169,6 +190,7 @@ function runAllTests() {
   test利用可能なプリセット一覧を取得できる();
   testプリセットからエディタURLを構築できる();
   testTerminalプリセットでコマンドを構築できる();
+  testコマンドコピータイプを判定できる();
   test現在のOS向けプリセットのみを取得できる();
   test無効なプリセットIDでエラーが発生する();
   


### PR DESCRIPTION
## Summary
- Chrome拡張環境でのTerminal起動に関する技術的制限を調査
- 実行不可能なTerminal系プリセットを無効化し、動作する機能のみを提供

## 調査結果
### Terminal URL Schemeの実態調査
- **macOS Terminal.app**: `terminal://` URL schemeは存在しない
- **iTerm2**: URL schemeは2011年にセキュリティ上の理由で削除済み
- **Windows Terminal**: URL scheme未サポート  
- **Linux GNOME Terminal**: 組み込みURL scheme無し

### Chrome拡張の技術的制限
- URL schemeでのシステムコマンド実行は不可能
- AppleScriptやshellコマンドの直接実行はセキュリティ制限により禁止
- コマンドコピー機能も実際の実行場所が不明瞭で使用困難

## 変更内容
### コード変更
- Terminal/iTerm2/Neovim系プリセットを無効化（コメントアウト）
- `COPY_COMMAND`プリセットタイプを削除
- popup.jsのコマンドコピー処理を削除
- settings.jsのTerminal系UI処理を簡素化
- テストケースを無効化確認用に変更

### 機能への影響
- **削除**: Terminal系プリセット（terminal_mac, iterm2, nvim_terminal）
- **保持**: GUI系プリセット（VSCode, Cursor）とコマンドライン系（Windsurf）
- **保持**: JetBrains Toolbox系プリセット

## Test Plan
- [x] 既存のGUI系プリセット（VSCode, Cursor）が正常動作することを確認
- [x] コマンドライン系プリセット（Windsurf）が正常動作することを確認  
- [x] Terminal系プリセットが適切にエラーを返すことを確認
- [x] 設定画面でTerminal系プリセットが表示されないことを確認
- [x] すべてのテストケースが通過することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)