### PR TITLE
fix: 言語ラベルの多言語化表示を修正

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -101,7 +101,7 @@
     </div>
     
     <div id="loading" class="loading">
-        <span data-i18n="popup.loading">読み込み中...</span>
+        <span data-i18n="popup.loading">Loading...</span>
     </div>
     
     <div id="content" style="display: none;">
@@ -112,10 +112,8 @@
         
         <div class="actions">
             <button id="openInEditor" class="btn btn-primary" data-i18n="popup.openInEditor">
-                エディタで開く
             </button>
             <button id="openSettings" class="btn btn-secondary" data-i18n="popup.settings">
-                設定
             </button>
         </div>
         

--- a/popup.js
+++ b/popup.js
@@ -217,6 +217,9 @@ async function initializeUI() {
   // I18nManagerを初期化
   i18n = new I18nManager();
   
+  // 初期表示用にデフォルト言語で翻訳を即座に適用
+  updateUI();
+  
   // 言語設定をロード
   await loadLanguageSettings();
   

--- a/settings.html
+++ b/settings.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="settings.pageTitle">GitHub Editor Opener - 設定</title>
+    <title data-i18n="settings.pageTitle">GitHub Editor Opener</title>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
@@ -147,14 +147,14 @@
     <div class="container">
         <div class="header">
             <h1>GitHub Editor Opener</h1>
-            <p data-i18n="settings.title">設定</p>
+            <p data-i18n="settings.title"></p>
         </div>
         
         <div id="message" class="message"></div>
         
         <form id="settingsForm">
             <div class="form-group">
-                <label for="language" data-i18n="settings.language">言語</label>
+                <label for="language" data-i18n="settings.language"></label>
                 <select id="language" name="language">
                     <option value="ja">日本語</option>
                     <option value="en">English</option>
@@ -165,7 +165,7 @@
             </div>
             
             <div class="form-group">
-                <label for="basePath" data-i18n="settings.basePath">ベースパス</label>
+                <label for="basePath" data-i18n="settings.basePath"></label>
                 <input type="text" id="basePath" name="basePath" placeholder="/Users/{username}/src/github.com/">
                 <div class="form-help" data-i18n="settings.basePathHelp">
                     GitHub リポジトリが配置されているベースパスを設定してください。<br>
@@ -178,9 +178,9 @@
             </div>
             
             <div class="form-group">
-                <label for="editorPreset" data-i18n="settings.editorPreset">エディタプリセット</label>
+                <label for="editorPreset" data-i18n="settings.editorPreset"></label>
                 <select id="editorPreset" name="editorPreset">
-                    <option value="custom" data-i18n="settings.customSetting">カスタム設定</option>
+                    <option value="custom" data-i18n="settings.customSetting"></option>
                 </select>
                 <div class="form-help" data-i18n="settings.editorPresetHelp">
                     よく使われるエディタから選択できます。「カスタム設定」を選ぶと手動で設定できます。
@@ -188,7 +188,7 @@
             </div>
             
             <div class="form-group">
-                <label for="editorScheme" data-i18n="settings.editorScheme">エディタ URL スキーム</label>
+                <label for="editorScheme" data-i18n="settings.editorScheme"></label>
                 <input type="text" id="editorScheme" name="editorScheme" placeholder="vscode://file" value="vscode://file">
                 <div class="form-help" data-i18n="settings.editorSchemeHelp">
                     使用するエディタの URL スキームを指定してください。<br>
@@ -203,10 +203,8 @@
         
         <div class="actions">
             <button type="submit" form="settingsForm" class="btn btn-primary" data-i18n="settings.saveSettings">
-                設定を保存
             </button>
             <button type="button" id="resetBtn" class="btn btn-secondary" data-i18n="settings.reset">
-                リセット
             </button>
         </div>
     </div>

--- a/settings.js
+++ b/settings.js
@@ -296,6 +296,9 @@ function initialize() {
   // I18nManagerを初期化
   i18n = new I18nManager();
   
+  // 初期表示用にデフォルト言語で翻訳を即座に適用
+  updateUI();
+  
   // エディタプリセットを初期化
   initializeEditorPresets();
   


### PR DESCRIPTION
## Issue
英語設定に切り替えても「言語」ラベルが日本語で表示される問題を修正。

## Root Cause
HTMLのデフォルトテキストが日本語で設定されており、初期化時の翻訳適用前に日本語が表示されてしまう問題。

## Solution

### HTMLテンプレート修正
- `data-i18n`属性を持つ要素のデフォルトテキストを削除または最小化
- 特に「言語」ラベルのデフォルトテキストを空にして翻訳に依存

### 初期化処理最適化
- I18nManager初期化直後に即座に翻訳を適用
- 言語設定ロード前にデフォルト言語（日本語）で表示

## Changes

### settings.html
```html
<\!-- Before -->
<label for="language" data-i18n="settings.language">言語</label>

<\!-- After -->
<label for="language" data-i18n="settings.language"></label>
```

### popup.html  
```html
<\!-- Before -->
<span data-i18n="popup.loading">読み込み中...</span>

<\!-- After -->
<span data-i18n="popup.loading">Loading...</span>
```

### settings.js/popup.js
```javascript
// 初期化直後に翻訳適用
i18n = new I18nManager();
updateUI(); // ← 追加
```

## Test Results
- ✅ 英語設定時に「Language」と正しく表示
- ✅ 日本語設定時に「言語」と正しく表示
- ✅ 既存機能に影響なし
- ✅ すべてのテストケース通過

🤖 Generated with [Claude Code](https://claude.ai/code)